### PR TITLE
Example in README.md has syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ aws_vpc_resource_tags:
   Name: Default VPC
   ProvisionedBy: Ansible
 aws_vpc_subnets:
-  - cidr_block: 172.0.0.0/24
+  - cidr: 172.0.0.0/24
     internet_gateway: true
     resource_tags:
       Name: Default Subnet


### PR DESCRIPTION
I am pretty sure the subnet needs to define cidr instead of cidr_block.  Executing fails when I use cidr_block.

$ ansible-playbook --version
ansible-playbook 1.9.4
